### PR TITLE
Update links to Tiny-T

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Printers covered currently include:
 - [Micron](https://github.com/hartk1213/Micron)
 - [Salad Fork](https://github.com/Yeriwyn/Salad_Fork)
 - [Tiny-M](https://github.com/gsl12/Tiny-M)
-- [Tiny-T](https://github.com/thiagolocatelli/Voron/tree/master/Tiny-T)
+- [Tiny-T](https://github.com/PrintersForAnts/TinyT)

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
         <div class="col-md-7 order-md-2">
           <h2 class="featurette-heading">Tiny-T. <span class="text-muted">A tiny Trident.</span></h2>
           <p class="lead">A Trident scaled <em>down</em> to same 150mm³ build volume as the bigger Salad Fork.</p>
-          <p><a class="btn btn-lg btn-primary" href="https://github.com/thiagolocatelli/Voron/tree/master/Tiny-T">More info about Tiny-T</a></p>
+          <p><a class="btn btn-lg btn-primary" href="https://github.com/PrintersForAnts/TinyT">More info about Tiny-T</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
Tiny-T moved to the PrintersForAnts GitHub org. Updated the website to reflect this.